### PR TITLE
remove unnecessary fixed scrollbar

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,12 +7,9 @@ import { routesWithElements } from "../consts/routes";
 const useAppStyles = createStyleHook(() => {
   return {
     root: {
-      height: "100%",
-      overflow: "hidden",
-      position: "fixed",
-      top: 0,
-      left: 0,
       width: "100%",
+      minHeight: "100vh",
+      overflowX: "hidden",
       backgroundColor: theme.palette.background.default,
     },
   };

--- a/src/components/pageComponents/PageContainer/PageContainer.tsx
+++ b/src/components/pageComponents/PageContainer/PageContainer.tsx
@@ -1,5 +1,5 @@
+import { FC, ReactNode } from "react";
 import { Box, Fade } from "@mui/material";
-import React, { FC, ReactNode } from "react";
 import { createStyleHook } from "../../../hooks/styleHooks";
 import { PageToolbar } from "../PageToolbar/PageToolbar";
 
@@ -11,7 +11,7 @@ const usePageContainerStyles = createStyleHook((theme) => {
   return {
     root: {
       width: "100%",
-      height: "100vh",
+      height: "100%",
       display: "flex",
       flexDirection: "column",
       alignItems: "center",

--- a/src/components/pageComponents/PageContainer/PageContainer.tsx
+++ b/src/components/pageComponents/PageContainer/PageContainer.tsx
@@ -11,8 +11,7 @@ const usePageContainerStyles = createStyleHook((theme) => {
   return {
     root: {
       width: "100%",
-      height: "100%",
-      overflowY: "scroll",
+      height: "100vh",
       display: "flex",
       flexDirection: "column",
       alignItems: "center",


### PR DESCRIPTION
![layout issue](https://github.com/DogFinderApp/dog-finder-app/assets/97472180/895d0b9a-b14c-4dd0-bd1e-f2613de68b89)

Here's how it looks in the new version:
![fixed layout](https://github.com/DogFinderApp/dog-finder-app/assets/97472180/6794a75f-39d4-4476-9380-a5488eafaf66)

And this as an example for a long page that has a scrollbar in it:
![fixed layout long](https://github.com/DogFinderApp/dog-finder-app/assets/97472180/359a2cb6-4dc6-4dfe-a9cc-23ef6add5435)
