### PR TITLE
fix: Hamal links not changing `selectedType` state and not refetching

### DIFF
--- a/src/components/pageComponents/PageToolbar/PageToolbar.tsx
+++ b/src/components/pageComponents/PageToolbar/PageToolbar.tsx
@@ -105,7 +105,7 @@ export const PageToolbar = () => {
       </IconButton>
       <Menu open={isMenuOpen} onClose={handleCloseMenu} anchorEl={anchorEl}>
         {linksToRender.map((link, index) => (
-          <>
+          <div key={link.text}>
             <Link
               key={link.text}
               to={link.href}
@@ -122,7 +122,7 @@ export const PageToolbar = () => {
             {index === 4 && isHamalUser && (
               <Divider variant="middle" sx={styles.divider} />
             )}
-          </>
+          </div>
         ))}
       </Menu>
     </Box>

--- a/src/components/pageComponents/PageToolbar/links.ts
+++ b/src/components/pageComponents/PageToolbar/links.ts
@@ -34,7 +34,7 @@ export const hamalLinks = [
     text: AppTexts.navigation.allLost,
   },
   {
-    href: AppRoutes.dogs.allReports.replace(":dogType", ""),
+    href: AppRoutes.dogs.allReports.replace("/:dogType", ""),
     text: AppTexts.allReportsPage.title,
   },
 ];

--- a/src/pages/dogs/AllReportsPage.tsx
+++ b/src/pages/dogs/AllReportsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { withAuthenticationRequired } from "@auth0/auth0-react";
 import {
@@ -153,7 +153,7 @@ export const AllReportsPage = withAuthenticationRequired(() => {
 
   const filteredReports: DogResult[] = getFilteredReports();
   const itemsPerPage = response?.pagination?.page_size ?? 12;
-  const paginatedReports = usePagination(filteredReports, itemsPerPage);
+  const paginatedReports = usePagination(filteredReports ?? [], itemsPerPage);
   const pagesCount: number =
     Math.ceil((response?.pagination?.total as number) / itemsPerPage) ?? 0;
 
@@ -165,10 +165,18 @@ export const AllReportsPage = withAuthenticationRequired(() => {
     setPage(newValue);
     paginatedReports.jump(newValue);
     window.scroll({ top: 0 });
+  };
+
+  useEffect(() => {
+    const pathName = window.location.pathname;
+    const urlParts = pathName.split("/");
+    const typeFromUrl = urlParts[urlParts.length - 1];
+    const newSelectedType = typeFromUrl === "all-reports" ? "all" : typeFromUrl;
+    setSelectedType(newSelectedType as SelectOptions);
     setTimeout(() => {
       mutate();
     }, 0);
-  };
+  }, [window.location.pathname, mutate]); // eslint-disable-line
 
   const changeSelectedReports = (event: SelectChangeEvent<any>) => {
     const { value } = event.target;


### PR DESCRIPTION
this issue happens when the user navigates between one of the "all-report" page to another

* update selectedType state and refetch whenever the url changes
* add keys to mapped links