### PR TITLE
fixing QA issues for stage1

### DIFF
--- a/src/components/Modals/MatchingReportModal.tsx
+++ b/src/components/Modals/MatchingReportModal.tsx
@@ -133,10 +133,13 @@ export default function MatchingReportModal({
             style={{ width: "100%", maxHeight: "400px" }}
           />
           <a
-            href={AppRoutes.dogs.dogPage.replace(
+            href={`${AppRoutes.dogs.dogPage.replace(
               ":dog_id",
               mostMatchingReport.dogId,
-            )}
+            )}no-return`}
+            // we want to disable the back button because we open that page in a new tab in it doesn't have
+            // a previous page to go back to. we can't use a Link and pass state in it either, again,
+            // because we open that page in a new tab. so we use the URL param `no-return` instead
             target="_blank"
             rel="noopener noreferrer"
             style={linkStyles}

--- a/src/consts/routes.ts
+++ b/src/consts/routes.ts
@@ -3,7 +3,7 @@ export const AppRoutes = {
   privacyPolicy: "/PrivacyPolicy",
   about: "/about",
   dogs: {
-    dogPage: "/dogs/:dog_id",
+    dogPage: "/dogs/:dog_id?",
     reportFound: "/report-found",
     reportLost: "/report-lost",
     searchFoundDog: "/search-found",

--- a/src/hooks/useImageSelection.ts
+++ b/src/hooks/useImageSelection.ts
@@ -17,8 +17,9 @@ const checkForMatchingDogs = async (
     });
     const json = await response.json();
     if (json?.data?.results) {
+      const threshold = 0.88;
       const filteredResults = json.data.results.filter(
-        (result: DogResult) => result?.score && result.score >= 0.995,
+        (result: DogResult) => result?.score && result.score >= threshold,
       );
       if (filteredResults.length) {
         setMatchingReports(filteredResults);

--- a/src/pages/dogs/DogDetailsPage/DogDetailsButtons.tsx
+++ b/src/pages/dogs/DogDetailsPage/DogDetailsButtons.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, To, useNavigate } from "react-router-dom";
 import { Box, Button, Typography } from "@mui/material";
 import { IconArrowLeft, TablerIconsProps } from "@tabler/icons-react";
 import { AppTexts } from "../../../consts/texts";
+import { AppRoutes } from "../../../consts/routes";
 import { useGetServerApi } from "../../../facades/ServerApi";
 import { DogDetailsReturnType } from "../../../types/DogDetailsTypes";
 import { DogType } from "../../../types/payload.types";
@@ -98,6 +99,8 @@ export const DogDetailsButtons = ({ data }: DogDetailsButtonsProps) => {
   // if a user has multiple reports, they should choose the one that matches with the dog page
   const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
 
+  const backButtonRedirectsToHome = window.location.href.includes("no-return");
+
   const lastReportedId: number | null = reports
     ? reports[reports.length - 1].id
     : null;
@@ -162,7 +165,9 @@ export const DogDetailsButtons = ({ data }: DogDetailsButtonsProps) => {
         size="large"
         variant="contained"
         sx={styles.actionBtnStyle}
-        onClick={() => navigate(-1)}
+        onClick={() =>
+          navigate(backButtonRedirectsToHome ? AppRoutes.root : (-1 as To))
+        }
       >
         <IconArrowLeft {...commonIconProps} />
         {backButton}

--- a/src/pages/dogs/ReportDogPage/useFormInputs.ts
+++ b/src/pages/dogs/ReportDogPage/useFormInputs.ts
@@ -164,7 +164,10 @@ export const useReportDogInputs = () => {
       },
       {
         name: "extraDetails",
-        label: reportPage.extraDetails.extraDetails,
+        label: matchGender(
+          reportPage.extraDetails.extraDetails,
+          selectedGender,
+        ),
         required: inputs.extraDetails.isRequired,
         multiline: true,
         rows: 5,


### PR DESCRIPTION
* change the threshold for opening `MatchingReportModal` from 0.995 to 0.88
* `DogDetailsButtons`: return button will navigate to homepage if there is no previous page in tab history
* fix: `ExtraDetails` input label not matching the dog's gender (after the user selects a gender in the form)